### PR TITLE
Neutrino, stop the chainservice before node DB.

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -246,6 +246,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 		// database.
 		walletConfig.ChainSource = chain.NewNeutrinoClient(svc)
 		cleanUp = func() {
+			svc.Stop()
 			nodeDatabase.Close()
 		}
 	case "bitcoind", "litecoind":


### PR DESCRIPTION
When in neutrino mode, it seems that the node is not closed during the cleanup, so if a block is received between the time the DB is closed and the server is closed (or if the process is still running after the server is shutdown like on a mobile app), the code panic's and crashes with:

panic: unable to write block header: database not open
goroutine 41 [running]:
github.com/lightningnetwork/lnd/vendor/github.com/lightninglabs/neutrino.(*blockManager).handleHeadersMsg(0x9a1ec0a0, 0x9a3e6030)
/ext-go/1/src/github.com/lightningnetwork/lnd/vendor/github.com/lightninglabs/neutrino/blockmanager.go:1164 +0x2224
github.com/lightningnetwork/lnd/vendor/github.com/lightninglabs/neutrino.(*blockManager).blockHandler(0x9a1ec0a0)
/ext-go/1/src/github.com/lightningnetwork/lnd/vendor/github.com/lightninglabs/neutrino/blockmanager.go:347 +0x3b4
created by github.com/lightningnetwork/lnd/vendor/github.com/lightninglabs/neutrino.(*blockManager).Start
/ext-go/1/src/github.com/lightningnetwork/lnd/vendor/github.com/lightninglabs/neutrino/blockmanager.go:200 +0xe8


Here's a log of shutdown before the change:
[INF] LTND: Gracefully shutting down the server...
[INF] FNDG: Funding manager shutting down
[INF] SPHX: Block epoch canceled, decaying hash log shutting down
[INF] CRTR: Channel Router shutting down
[INF] CRTR: FilteredChainView stopping
[INF] HSWC: HTLC Switch shutting down
[INF] UTXN: UTXO nursery shutting down
[INF] BRAR: Breach arbiter shutting down
[INF] DISC: Authenticated Gossiper is stopping
[INF] CNCT: Stopping ChainArbitrator
[INF] LTND: Shutdown complete


And here's a log of shutdown after the change:
[INF] LTND: Gracefully shutting down the server...
[INF] FNDG: Funding manager shutting down
[INF] SPHX: Block epoch canceled, decaying hash log shutting down
[INF] CRTR: Channel Router shutting down
[INF] CRTR: FilteredChainView stopping
[INF] HSWC: HTLC Switch shutting down
[INF] UTXN: UTXO nursery shutting down
[INF] BRAR: Breach arbiter shutting down
[INF] DISC: Authenticated Gossiper is stopping
[INF] CNCT: Stopping ChainArbitrator
[INF] LTND: Shutdown complete
[INF] BTCN: Block manager shutting down
[INF] BTCN: Address manager shutting down